### PR TITLE
Separate the concept of deployments from a node object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,13 @@ git:
 install:        true
 services:
   - docker
+before_install:
+  - sudo apt-get install -y genisoimage
 before_script:
   - docker run -d --net host --privileged --name mariadb --entrypoint /bin/runmariadb quay.io/metal3-io/ironic
   - docker run -d --net host --privileged -e "IP=0.0.0.0" --name ironic quay.io/metal3-io/ironic
-  - docker run --net host -e TARGETS=127.0.0.1:3306,127.0.0.1:6385 -e TIMEOUT=60 waisbrot/wait
+  - docker run -d --net host --privileged -e "IP=0.0.0.0" --net host quay.io/metal3-io/metalkube-ironic-inspector
+  - docker run --net host -e TARGETS=127.0.0.1:3306,127.0.0.1:6385,127.0.0.1:5050 -e TIMEOUT=60 waisbrot/wait
 script:
   - make fmt
   - make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 before_script:
   - docker run -d --net host --privileged --name mariadb --entrypoint /bin/runmariadb quay.io/metal3-io/ironic
   - docker run -d --net host --privileged -e "IP=0.0.0.0" --name ironic quay.io/metal3-io/ironic
-  - docker run -d --net host --privileged -e "IP=0.0.0.0" --net host quay.io/metal3-io/metalkube-ironic-inspector
+  - docker run -d --net host --privileged -e "IP=0.0.0.0" --net host quay.io/metal3-io/ironic-inspector
   - docker run --net host -e TARGETS=127.0.0.1:3306,127.0.0.1:6385,127.0.0.1:5050 -e TIMEOUT=60 waisbrot/wait
 script:
   - make fmt

--- a/README.md
+++ b/README.md
@@ -24,13 +24,20 @@ described below.
 
 ### Nodes
 
-A node describes a hardware resource.
+A node describes a hardware resource.  A limited subset of provision
+states are supported, you may specify `manage = true` or `available =
+true`.  You may also instruct Ironic to inspect (`inspect = true`) or
+clean (`clean = true`) the node.  To bring a node to the `active` state,
+i.e. deploy the node - use a deployment resource instead.
+
 
 ```terraform
 resource "ironic_node_v1" "openshift-master-0" {
   name = "openshift-master-0"
-  target_provision_state = "active"
-  user_data = "${file("master.ign")}"
+
+  inspect = true      # Perform inspection
+  clean = true        # Clean the node
+  available = true    # Make the node 'available'
 
   ports = [
     {
@@ -42,13 +49,6 @@ resource "ironic_node_v1" "openshift-master-0" {
   properties {
     "local_gb" = "50"
     "cpu_arch" =  "x86_64"
-  }
-
-  instance_info = {
-    "image_source" = "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
-    "image_checksum" = "26c53f3beca4e0b02e09d335257826fd"
-    "root_gb" = "25"
-    "root_device" = "/dev/vda"
   }
 
   driver = "ipmi"
@@ -98,6 +98,39 @@ resource "ironic_allocation_v1" "openshift-master-allocation" {
     "CUSTOM_FOO",
   ]
 }
+```
+
+## Deployment
+
+A deployment will provision a baremetal node, using the information
+given in the resource.  The `count` metaparameter can be used to deploy
+multiple nodes. Terraform will drive the [Ironic state
+machine](https://docs.openstack.org/ironic/latest/contributor/states.html)
+to bring the node to an `active` state.  The separation of deployment
+from the baremetal node defintion allows a user to manage their hardware
+outside of the provider if desired. Destruction of a deployment brings
+the baremetal node back to the `available` state.
+
+Users may specify a `node_uuid` directly, or make use of the allocation
+resource to dynamically pick a node.
+
+
+```
+resource "ironic_deployment" "masters"  {
+  count = 3
+  node_uuid = "${ironic_allocation_v1.openshift-master-allocation[$count.index].node_uuid}"
+
+  instance_info {
+    user_data      = "${file("master.ign")}"
+    image_source   = "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
+    image_checksum = "26c53f3beca4e0b02e09d335257826fd"
+  }
+
+  user_data = "${var.user_data}"
+  network_data = "${var.network_data}"
+  metadata = "${var.metadata}"
+}
+
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Users may specify a `node_uuid` directly, or make use of the allocation
 resource to dynamically pick a node.
 
 
-```
+```terraform
 resource "ironic_deployment" "masters"  {
   count = 3
   node_uuid = "${ironic_allocation_v1.openshift-master-allocation[$count.index].node_uuid}"
@@ -130,7 +130,6 @@ resource "ironic_deployment" "masters"  {
   network_data = "${var.network_data}"
   metadata = "${var.metadata}"
 }
-
 ```
 
 # License

--- a/ironic/provider.go
+++ b/ironic/provider.go
@@ -28,6 +28,7 @@ func Provider() terraform.ResourceProvider {
 			"ironic_node_v1":       resourceNodeV1(),
 			"ironic_port_v1":       resourcePortV1(),
 			"ironic_allocation_v1": resourceAllocationV1(),
+			"ironic_deployment":    resourceDeployment(),
 		},
 		ConfigureFunc: configureProvider,
 	}

--- a/ironic/resource_ironic_allocation_v1.go
+++ b/ironic/resource_ironic_allocation_v1.go
@@ -128,9 +128,15 @@ func resourceAllocationV1Read(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-// Delete an allocation from Ironic
+// Delete an allocation from Ironic if it exists
 func resourceAllocationV1Delete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gophercloud.ServiceClient)
+
+	_, err := allocations.Get(client, d.Id()).Extract()
+	if _, ok := err.(gophercloud.ErrDefault404); ok {
+		return nil
+	}
+
 	return allocations.Delete(client, d.Id()).ExtractErr()
 }
 

--- a/ironic/resource_ironic_allocation_v1_test.go
+++ b/ironic/resource_ironic_allocation_v1_test.go
@@ -101,7 +101,7 @@ func testAccAllocationResource(node, resourceClass, allocation string) string {
 		resource "ironic_node_v1" "%s" {
 			name = "%s"
 			driver = "fake-hardware"
-			target_provision_state = "provide"
+			available = true
 			target_power_state = "power off"
 
 			boot_interface = "fake"

--- a/ironic/resource_ironic_deployment.go
+++ b/ironic/resource_ironic_deployment.go
@@ -1,0 +1,117 @@
+package ironic
+
+import (
+	"fmt"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	utils "github.com/gophercloud/utils/openstack/baremetal/v1/nodes"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// Schema resource definition for an Ironic deployment.
+func resourceDeployment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDeploymentCreate,
+		Read:   resourceDeploymentRead,
+		Delete: resourceDeploymentDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"node_uuid": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"instance_info": {
+				Type:     schema.TypeMap,
+				Required: true,
+				ForceNew: true,
+			},
+			"user_data": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"network_data": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+			"provision_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_error": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// Create an deployment, including driving Ironic's state machine
+func resourceDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gophercloud.ServiceClient)
+
+	// Reload the resource before returning
+	defer resourceDeploymentRead(d, meta)
+
+	// Set instance info
+	instanceInfo := d.Get("instance_info").(map[string]interface{})
+	if instanceInfo != nil {
+		_, err := nodes.Update(client, d.Get("node_uuid").(string), nodes.UpdateOpts{
+			nodes.UpdateOperation{
+				Op:    nodes.AddOp,
+				Path:  "/instance_info",
+				Value: instanceInfo,
+			},
+		}).Extract()
+		if err != nil {
+			return fmt.Errorf("could not update instance info: %s", err)
+		}
+	}
+
+	// Create config drive
+	configDrive := utils.ConfigDrive{
+		UserData:    utils.UserDataString(d.Get("user_data").(string)),
+		NetworkData: d.Get("network_data").(map[string]interface{}),
+		MetaData:    d.Get("metadata").(map[string]interface{}),
+	}
+
+	d.SetId(d.Get("node_uuid").(string))
+
+	// Deploy the node - drive Ironic state machine until node is 'active'
+	return ChangeProvisionStateToTarget(client, d.Id(), "active", &configDrive)
+}
+
+// Read the deployment's data from Ironic
+func resourceDeploymentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gophercloud.ServiceClient)
+
+	// Ensure node exists first
+	id := d.Get("node_uuid").(string)
+	result, err := nodes.Get(client, id).Extract()
+	if err != nil {
+		return fmt.Errorf("could not find node %s: %s", id, err)
+	}
+
+	d.Set("provision_state", result.ProvisionState)
+	d.Set("last_error", result.LastError)
+
+	return nil
+}
+
+// Delete an deployment from Ironic - this cleans the node and returns it's state to 'available'
+func resourceDeploymentDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gophercloud.ServiceClient)
+	return ChangeProvisionStateToTarget(client, d.Id(), "deleted", nil)
+}

--- a/ironic/resource_ironic_deployment_test.go
+++ b/ironic/resource_ironic_deployment_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	th "github.com/openshift-metalkube/terraform-provider-ironic/testhelper"
+	th "github.com/openshift-metal3/terraform-provider-ironic/testhelper"
 )
 
 // Creates a node, and an allocation that should use it
@@ -22,8 +22,8 @@ func TestAccIronicDeployment(t *testing.T) {
 	resourceClass := th.RandomString("baremetal-", 8)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
 		CheckDestroy: testAccDeploymentDestroy,
 		Steps: []resource.TestStep{
 			// Create a test deployment

--- a/ironic/resource_ironic_deployment_test.go
+++ b/ironic/resource_ironic_deployment_test.go
@@ -1,0 +1,95 @@
+// +build acceptance
+
+package ironic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	th "github.com/openshift-metalkube/terraform-provider-ironic/testhelper"
+)
+
+// Creates a node, and an allocation that should use it
+func TestAccIronicDeployment(t *testing.T) {
+	var node nodes.Node
+
+	nodeName := th.RandomString("TerraformACC-Node-", 8)
+	allocationName := th.RandomString("TerraformACC-Allocation-", 8)
+	resourceClass := th.RandomString("baremetal-", 8)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: testAccDeploymentDestroy,
+		Steps: []resource.TestStep{
+			// Create a test deployment
+			{
+				Config: testAccDeploymentResource(nodeName, resourceClass, allocationName),
+				Check: resource.ComposeTestCheckFunc(
+					CheckNodeExists("ironic_node_v1."+nodeName, &node),
+					resource.TestCheckResourceAttr("ironic_deployment."+nodeName, "provision_state", "active"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDeploymentDestroy(state *terraform.State) error {
+	client := testAccProvider.Meta().(*gophercloud.ServiceClient)
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "ironic_node_v1" {
+			continue
+		}
+
+		_, err := nodes.Get(client, rs.Primary.ID).Extract()
+		if _, ok := err.(gophercloud.ErrDefault404); !ok {
+			return fmt.Errorf("unexpected error: %s, expected 404", err)
+		}
+	}
+
+	return nil
+}
+
+func testAccDeploymentResource(node, resourceClass, allocation string) string {
+	return fmt.Sprintf(`
+		resource "ironic_node_v1" "%s" {
+			name = "%s"
+			driver = "fake-hardware"
+			available = true
+			target_power_state = "power off"
+
+			boot_interface = "fake"
+			deploy_interface = "fake"
+			management_interface = "fake"
+			power_interface = "fake"
+			resource_class = "%s"
+			vendor_interface = "no-vendor"
+		}
+
+		resource "ironic_allocation_v1" "%s" {
+			name = "%s"
+			resource_class = "%s"
+			candidate_nodes = [
+				"${ironic_node_v1.%s.id}"
+			]
+		}
+
+		resource "ironic_deployment" "%s" {
+			name = "%s"
+			node_uuid = "${ironic_allocation_v1.%s.node_uuid}"
+			instance_info {
+				image_source   = "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
+				image_checksum = "26c53f3beca4e0b02e09d335257826fd"
+				root_gb = "25"
+			}
+
+			user_data = "asdf"
+		}
+
+`, node, node, resourceClass, allocation, allocation, resourceClass, node, node, node, allocation)
+}

--- a/ironic/resource_ironic_node_v1_test.go
+++ b/ironic/resource_ironic_node_v1_test.go
@@ -30,13 +30,33 @@ func TestAccIronicNode(t *testing.T) {
 				),
 			},
 
-			// Change the node's provision state to 'available'
+			// Ensure node is manageable
 			{
-				Config: testAccNodeResource("target_provision_state = \"provide\""),
+				Config: testAccNodeResource("manage = true"),
 				Check: resource.ComposeTestCheckFunc(
 					CheckNodeExists("ironic_node_v1.node-0", &node),
 					resource.TestCheckResourceAttr("ironic_node_v1.node-0",
-						"provision_state", "available"),
+						"provision_state", "manageable"),
+				),
+			},
+
+			// Inspect the node
+			{
+				Config: testAccNodeResource("inspect = true"),
+				Check: resource.ComposeTestCheckFunc(
+					CheckNodeExists("ironic_node_v1.node-0", &node),
+					resource.TestCheckResourceAttr("ironic_node_v1.node-0",
+						"provision_state", "manageable"),
+				),
+			},
+
+			// Clean the node
+			{
+				Config: testAccNodeResource("clean = true"),
+				Check: resource.ComposeTestCheckFunc(
+					CheckNodeExists("ironic_node_v1.node-0", &node),
+					resource.TestCheckResourceAttr("ironic_node_v1.node-0",
+						"provision_state", "manageable"),
 				),
 			},
 
@@ -129,6 +149,7 @@ func testAccNodeResource(extraValue string) string {
 
 			boot_interface = "pxe"
 			deploy_interface = "fake"
+			inspect_interface = "fake"
 			management_interface = "fake"
 			power_interface = "fake"
 			resource_class = "baremetal"

--- a/ironic/workflow.go
+++ b/ironic/workflow.go
@@ -1,0 +1,294 @@
+package ironic
+
+import (
+	"fmt"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	utils "github.com/gophercloud/utils/openstack/baremetal/v1/nodes"
+	"log"
+	"time"
+)
+
+// provisionStateWorkflow is used to track state through the process of updating's it's provision state
+type provisionStateWorkflow struct {
+	client *gophercloud.ServiceClient
+	node   nodes.Node
+	uuid   string
+	target string
+	wait   time.Duration
+
+	configDrive *utils.ConfigDrive
+}
+
+// ChangeProvisionStateToTarget drives Ironic's state machine through the process to reach our desired end state. This requires multiple
+// possibly long-running steps.  If required, we'll build a config drive ISO for deployment.
+func ChangeProvisionStateToTarget(client *gophercloud.ServiceClient, uuid, target string, configDrive *utils.ConfigDrive) error {
+
+	// Run the provisionStateWorkflow - this could take a while
+	wf := provisionStateWorkflow{
+		target:      target,
+		client:      client,
+		wait:        5 * time.Second,
+		uuid:        uuid,
+		configDrive: configDrive,
+	}
+
+	err := wf.run()
+	return err
+}
+
+// Keep driving the state machine forward
+func (workflow *provisionStateWorkflow) run() error {
+	log.Printf("[INFO] Beginning provisioning workflow, will try to change node to state '%s'", workflow.target)
+
+	for {
+		done, err := workflow.next()
+		if done || err != nil {
+			return err
+		}
+
+		time.Sleep(workflow.wait)
+	}
+
+	return nil
+}
+
+// Do the next thing to get us to our target state
+func (workflow *provisionStateWorkflow) next() (done bool, err error) {
+	// Refresh the node on each run
+	if err := workflow.reloadNode(); err != nil {
+		return true, err
+	}
+
+	log.Printf("[DEBUG] Node current state is '%s'", workflow.node.ProvisionState)
+
+	switch target := nodes.TargetProvisionState(workflow.target); target {
+	case nodes.TargetManage:
+		return workflow.toManageable()
+	case nodes.TargetProvide:
+		return workflow.toAvailable()
+	case nodes.TargetActive:
+		return workflow.toActive()
+	case nodes.TargetDeleted:
+		return workflow.toDeleted()
+	case nodes.TargetClean:
+		return workflow.toClean()
+	case nodes.TargetInspect:
+		return workflow.toInspect()
+	default:
+		return true, fmt.Errorf("unknown target state '%s'", target)
+	}
+}
+
+// Change a node to "manageable" stable
+func (workflow *provisionStateWorkflow) toManageable() (done bool, err error) {
+	switch state := workflow.node.ProvisionState; state {
+	case "manageable":
+		// We're done!
+		return true, err
+	case "enroll",
+		"adopt failed",
+		"clean failed",
+		"inspect failed",
+		"available":
+		return workflow.changeProvisionState(nodes.TargetManage)
+	case "verifying":
+		// Not done, no error - Ironic is working
+		return false, nil
+
+	default:
+		return true, fmt.Errorf("cannot go from state '%s' to state 'manageable'", state)
+	}
+
+	return false, nil
+}
+
+// Clean a node
+func (workflow *provisionStateWorkflow) toClean() (done bool, err error) {
+	// Node must be manageable first
+	workflow.reloadNode()
+	if workflow.node.ProvisionState != nodes.Manageable {
+		if err := ChangeProvisionStateToTarget(workflow.client, workflow.uuid, nodes.TargetManage, nil); err != nil {
+			return true, err
+		}
+	}
+
+	// Set target to clean
+	workflow.changeProvisionState(nodes.TargetClean)
+
+	for {
+		workflow.reloadNode()
+		state := workflow.node.ProvisionState
+
+		switch state {
+		case "manageable":
+			return true, nil
+		case "cleaning",
+			"clean wait":
+			// Not done, no error - Ironic is working
+			continue
+		default:
+			return true, fmt.Errorf("could not clean node, node is currently '%s', last error was '%s'", state, workflow.node.LastError)
+		}
+	}
+
+	return true, nil
+}
+
+// Inspect a node
+func (workflow *provisionStateWorkflow) toInspect() (done bool, err error) {
+	// Node must be manageable first
+	workflow.reloadNode()
+	if workflow.node.ProvisionState != nodes.Manageable {
+		if err := ChangeProvisionStateToTarget(workflow.client, workflow.uuid, nodes.TargetManage, nil); err != nil {
+			return true, err
+		}
+	}
+
+	// Set target to inspect
+	workflow.changeProvisionState(nodes.TargetInspect)
+
+	for {
+		workflow.reloadNode()
+		state := workflow.node.ProvisionState
+
+		switch state {
+		case "manageable":
+			return true, nil
+		case "inspecting",
+			"inspect wait":
+			// Not done, no error - Ironic is working
+			continue
+		default:
+			return true, fmt.Errorf("could not inspect node, node is currently '%s', last error was '%s'", state, workflow.node.LastError)
+		}
+	}
+
+	return true, nil
+}
+
+// Change a node to "available" state
+func (workflow *provisionStateWorkflow) toAvailable() (done bool, err error) {
+	switch state := workflow.node.ProvisionState; state {
+	case "available":
+		// We're done!
+		return true, nil
+	case "cleaning",
+		"clean wait":
+		// Not done, no error - Ironic is working
+		log.Printf("[DEBUG] Node %s is '%s', waiting for Ironic to finish.", workflow.uuid, state)
+		return false, nil
+	case "manageable":
+		// From manageable, we can go to provide
+		log.Printf("[DEBUG] Node %s is '%s', going to change to 'available'", workflow.uuid, state)
+		return workflow.changeProvisionState(nodes.TargetProvide)
+	default:
+		// Otherwise we have to get into manageable state first
+		log.Printf("[DEBUG] Node %s is '%s', going to change to 'manageable'.", workflow.uuid, state)
+		_, err := workflow.toManageable()
+		if err != nil {
+			return true, err
+		}
+		return false, nil
+	}
+
+	return false, nil
+}
+
+// Change a node to "active" state
+func (workflow *provisionStateWorkflow) toActive() (bool, error) {
+
+	switch state := workflow.node.ProvisionState; state {
+	case "active":
+		// We're done!
+		log.Printf("[DEBUG] Node %s is 'active', we are done.", workflow.uuid)
+		return true, nil
+	case "deploying",
+		"wait call-back":
+		// Not done, no error - Ironic is working
+		log.Printf("[DEBUG] Node %s is '%s', waiting for Ironic to finish.", workflow.uuid, state)
+		return false, nil
+	case "available":
+		// From available, we can go to active
+		log.Printf("[DEBUG] Node %s is 'available', going to change to 'active'.", workflow.uuid)
+		workflow.wait = 30 * time.Second // Deployment takes a while
+		return workflow.changeProvisionState(nodes.TargetActive)
+	default:
+		// Otherwise we have to get into available state first
+		log.Printf("[DEBUG] Node %s is '%s', going to change to 'available'.", workflow.uuid, state)
+		_, err := workflow.toAvailable()
+		if err != nil {
+			return true, err
+		}
+		return false, nil
+	}
+}
+
+// Change a node to be "deleted," and remove the object from Ironic
+func (workflow *provisionStateWorkflow) toDeleted() (bool, error) {
+	switch state := workflow.node.ProvisionState; state {
+	case "manageable",
+		"available",
+		"enroll":
+		// We're done deleting the node
+		return true, nil
+	case "cleaning",
+		"deleting":
+		// Not done, no error - Ironic is working
+		log.Printf("[DEBUG] Node %s is '%s', waiting for Ironic to finish.", workflow.uuid, state)
+		return false, nil
+	case "active",
+		"wait call-back",
+		"deploy failed",
+		"error":
+		log.Printf("[DEBUG] Node %s is '%s', going to change to 'deleted'.", workflow.uuid, state)
+		return workflow.changeProvisionState(nodes.TargetDeleted)
+	case "inspect failed",
+		"clean failed":
+		// We have to get into manageable state first
+		log.Printf("[DEBUG] Node %s is '%s', going to change to 'manageable'.", workflow.uuid, state)
+		_, err := workflow.toManageable()
+		if err != nil {
+			return true, err
+		}
+		return false, nil
+	default:
+		return true, fmt.Errorf("cannot delete node in state '%s'", state)
+	}
+
+	return false, nil
+}
+
+// Builds the ProvisionStateOpts to send to Ironic -- including config drive.
+func (workflow *provisionStateWorkflow) buildProvisionStateOpts(target nodes.TargetProvisionState) (*nodes.ProvisionStateOpts, error) {
+	opts := nodes.ProvisionStateOpts{
+		Target: target,
+	}
+
+	// If we're deploying, then build a config drive to send to Ironic
+	if target == "active" {
+		configDriveData, err := workflow.configDrive.ToConfigDrive()
+		if err != nil {
+			return nil, err
+		}
+		opts.ConfigDrive = configDriveData
+	}
+
+	return &opts, nil
+}
+
+// Call Ironic's API and issue the change provision state request.
+func (workflow *provisionStateWorkflow) changeProvisionState(target nodes.TargetProvisionState) (done bool, err error) {
+	opts, err := workflow.buildProvisionStateOpts(target)
+	if err != nil {
+		log.Printf("[ERROR] Unable to construct provisioning state options: %s", err.Error())
+		return true, err
+	}
+
+	return false, nodes.ChangeProvisionState(workflow.client, workflow.uuid, *opts).ExtractErr()
+}
+
+// Call Ironic's API and reload the node's current state
+func (workflow *provisionStateWorkflow) reloadNode() error {
+	return nodes.Get(workflow.client, workflow.uuid).ExtractInto(&workflow.node)
+}


### PR DESCRIPTION
This resolves:
- #11: instance_uuid is now set when using an allocation.
- #6: destruction of a deployment returns the node to an available state, destruction of the node resource does remove it from Ironic

This PR allows us to consume existing nodes discovered by Ironic, and splits the concept of a deployment from the baremetal node object.  See README.md for more details on how deployments work.  

This is mostly future-looking, to a KNI world where we power on the hardware early and the nodes get discovered.  We don't need to be as attached to the specific node that becomes a specific master, as we can use Ironic allocations to just give us anything that matches our criteria.

This also enables the ability to do inspection and cleaning on a node before deploying it, and fixes some issues like not setting instance_uuid on a node when we deploy it.