### PR TITLE
Address warnings from terraform 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist:     xenial
 sudo:     false
 language: go
 env:
-  - TF_ACC=true TAGS="acceptance"
+  - TF_LOG=debug TF_ACC=true TAGS="acceptance"
 go:
   - 1.11.x
 git:

--- a/ironic/resource_ironic_allocation_v1.go
+++ b/ironic/resource_ironic_allocation_v1.go
@@ -35,6 +35,7 @@ func resourceAllocationV1() *schema.Resource {
 				},
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"traits": {
 				Type: schema.TypeList,

--- a/ironic/resource_ironic_node_v1.go
+++ b/ironic/resource_ironic_node_v1.go
@@ -27,7 +27,7 @@ func resourceNodeV1() *schema.Resource {
 			"boot_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "ipxe",
+				Computed: true,
 			},
 			"clean": {
 				Type:     schema.TypeBool,
@@ -36,16 +36,17 @@ func resourceNodeV1() *schema.Resource {
 			"conductor_group": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"console_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "no-console",
+				Computed: true,
 			},
 			"deploy_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "direct",
+				Computed: true,
 			},
 			"driver": {
 				Type:     schema.TypeString,
@@ -82,7 +83,7 @@ func resourceNodeV1() *schema.Resource {
 			"inspect_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "inspector",
+				Computed: true,
 			},
 			"instance_uuid": {
 				Type:     schema.TypeString,
@@ -103,27 +104,27 @@ func resourceNodeV1() *schema.Resource {
 			"management_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "ipmitool",
+				Computed: true,
 			},
 			"network_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "noop",
+				Computed: true,
 			},
 			"power_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "ipmitool",
+				Computed: true,
 			},
 			"raid_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "no-raid",
+				Computed: true,
 			},
 			"rescue_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "no-rescue",
+				Computed: true,
 			},
 			"resource_class": {
 				Type:     schema.TypeString,
@@ -132,16 +133,17 @@ func resourceNodeV1() *schema.Resource {
 			"storage_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "noop",
+				Computed: true,
 			},
 			"vendor_interface": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "ipmitool",
+				Computed: true,
 			},
 			"owner": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"ports": {
 				Type:     schema.TypeSet,
@@ -170,6 +172,7 @@ func resourceNodeV1() *schema.Resource {
 			"power_state_timeout": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 		},
 	}


### PR DESCRIPTION
refs #24

This partially addresses the issue. When some values are unspecified,
Ironic sets default values and returns the result the next time we
reload the resource. In 0.11, I used 'Default' to have terraform avoid
being surprised, but the better solution is to mark them Computed. This
informs terraform that if the resource doesn't define a value, Ironic
will. This removes most of the warnings in 0.12.