### PR TITLE
Fix container configuration for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_install:
   - sudo apt-get install -y genisoimage
 before_script:
   - docker run -d --net host --privileged --name mariadb --entrypoint /bin/runmariadb quay.io/metal3-io/ironic:master
-  - docker run -d --net host --privileged -e "IP=0.0.0.0" --name ironic quay.io/metal3-io/ironic:master
-  - docker run -d --net host --privileged -e "IP=0.0.0.0" --net host quay.io/metal3-io/ironic-inspector:master
+  - docker run -d --net host --privileged -e "PROVISIONING_INTERFACE=lo" --name ironic quay.io/metal3-io/ironic:master
+  - docker run -d --net host --privileged -e "PROVISIONING_INTERFACE=lo" --net host quay.io/metal3-io/ironic-inspector:master
   - docker run --net host -e TARGETS=127.0.0.1:3306,127.0.0.1:6385,127.0.0.1:5050 -e TIMEOUT=60 waisbrot/wait
 script:
   - make fmt


### PR DESCRIPTION
PROVISIONING_INTERFACE has replaced the IP environment variable in
Metal3's ironic containers.