### PR TITLE
Add timeout option to provider to wait for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,17 @@ optionally specify an API microversion.
 If you are using Ironic inspector, you may also specify the inspector
 URL if you'd like to use the introspection data source.
 
+The timeout option sets the number of seconds that the provider will wait
+for the Ironic or Inspector API's to become available. This is useful in cases
+where another terraform provider is responsible for bringing up the Ironic
+infrastructure.
+
 ```terraform
 provider "ironic" {
   url          = "http://localhost:6385/v1"
   inspector    = "http://localhost:5050/v1"
   microversion = "1.52"
+  timeout      = 900
 }
 ```
 

--- a/ironic/data_source_ironic_introspection.go
+++ b/ironic/data_source_ironic_introspection.go
@@ -67,9 +67,9 @@ func dataSourceIronicIntrospection() *schema.Resource {
 }
 
 func dataSourceIronicIntrospectionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Inspector
-	if client == nil {
-		return fmt.Errorf("inspector endpoint was not defined")
+	client, err := meta.(*Clients).GetInspectorClient()
+	if err != nil {
+		return err
 	}
 
 	uuid := d.Get("uuid").(string)

--- a/ironic/provider.go
+++ b/ironic/provider.go
@@ -8,12 +8,86 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"log"
+	"net/http"
+	"sync"
+	"time"
 )
 
 // Clients stores the client connection information for Ironic and Inspector
 type Clients struct {
-	Ironic    *gophercloud.ServiceClient
-	Inspector *gophercloud.ServiceClient
+	ironic    *gophercloud.ServiceClient
+	inspector *gophercloud.ServiceClient
+
+	// Boolean that determines if Ironic API was previously determined to be available, we don't need to try every time.
+	ironicUp bool
+
+	// Boolean that determines we've already waited and the API never came up, we don't need to wait again.
+	ironicFailed bool
+
+	// Mutex so that only one resource being created by terraform checks at a time. There's no reason to have multiple
+	// resources calling out to the API.
+	ironicMux sync.Mutex
+
+	// Boolean that determines if Inspector API was previously determined to be available, we don't need to try every time.
+	inspectorUp bool
+
+	// Boolean that determines that we've already waited, and inspector API did not come up.
+	inspectorFailed bool
+
+	// Mutex so that only one resource being created by terraform checks at a time. There's no reason to have multiple
+	// resources calling out to the API.
+	inspectorMux sync.Mutex
+
+	timeout int
+}
+
+// GetIronicClient returns the API client for Ironic, optionally retrying to reach the API if timeout is set.
+func (c *Clients) GetIronicClient() (*gophercloud.ServiceClient, error) {
+	c.ironicMux.Lock()
+	defer c.ironicMux.Unlock()
+
+	// Ironic is UP, or user didn't ask us to check
+	if c.ironicUp || c.timeout == 0 {
+		return c.ironic, nil
+	}
+
+	if c.ironicFailed {
+		return nil, fmt.Errorf("could not contact API: timeout reached")
+	}
+
+	// Wait the specified interval for Ironic to come up
+	err := waitForAPI(c.timeout, c.ironic)
+	if err != nil {
+		c.ironicFailed = true
+		return nil, err
+
+	}
+
+	c.ironicUp = true
+	return c.ironic, nil
+}
+
+// GetInspectorClient returns the API client for Ironic, optionally retrying to reach the API if timeout is set.
+func (c *Clients) GetInspectorClient() (*gophercloud.ServiceClient, error) {
+	c.inspectorMux.Lock()
+	defer c.inspectorMux.Unlock()
+
+	if c.inspector == nil {
+		return nil, fmt.Errorf("no inspector endpoint was specified")
+	} else if c.inspectorUp || c.timeout == 0 {
+		return c.inspector, nil
+	} else if c.inspectorFailed {
+		return nil, fmt.Errorf("could not contact API: timeout reached")
+	}
+
+	err := waitForAPI(c.timeout, c.inspector)
+	if err != nil {
+		c.inspectorFailed = true
+		return nil, err
+	}
+
+	c.inspectorUp = true
+	return c.inspector, nil
 }
 
 // Provider Ironic
@@ -38,6 +112,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("IRONIC_MICROVERSION", "1.52"),
 				Description: descriptions["microversion"],
 			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: descriptions["timeout"],
+				Default:     0,
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"ironic_node_v1":       resourceNodeV1(),
@@ -59,6 +139,7 @@ func init() {
 		"url":          "The authentication endpoint for Ironic",
 		"inspector":    "The endpoint for Ironic inspector",
 		"microversion": "The microversion to use for Ironic",
+		"timeout":      "Wait at least the specified number of seconds for the API to become available",
 	}
 }
 
@@ -79,7 +160,7 @@ func configureProvider(schema *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 	ironic.Microversion = schema.Get("microversion").(string)
-	clients.Ironic = ironic
+	clients.ironic = ironic
 
 	inspectorURL := schema.Get("inspector").(string)
 	if inspectorURL != "" {
@@ -90,8 +171,48 @@ func configureProvider(schema *schema.ResourceData) (interface{}, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not configure inspector endpoint: %s", err.Error())
 		}
-		clients.Inspector = inspector
+		clients.inspector = inspector
 	}
 
-	return clients, err
+	clients.timeout = schema.Get("timeout").(int)
+
+	return &clients, err
+}
+
+// Retries an API until a timeout is reached. The timeout is approximate, we calculate approximately
+// the number of attempts that would equal that timeout. It's not exact, but it will be *at least* the
+// value specified.
+func waitForAPI(timeout int, client *gophercloud.ServiceClient) error {
+	var maxTries int
+	if timeout < 5 {
+		maxTries = 1
+	} else {
+		maxTries = timeout / 5
+	}
+	log.Printf("[DEBUG] Waiting for Ironic API to become available - max attempts is %d", maxTries)
+
+	httpClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	for tries := 1; tries <= maxTries; tries++ {
+		// FIXME(stbenjam): After we sleep at the end of the loop, *something* is changing log output to be discarded, and
+		// when we get woken up again, our logs aren't printed anymore until the end of the loop. Very odd error, possibly
+		// something in terraform is doing this.
+		log.Printf("[DEBUG] Trying to connect to API, attempt %d of %d\n", tries, maxTries)
+
+		r, err := httpClient.Get(client.Endpoint)
+		if err == nil {
+			statusCode := r.StatusCode
+			r.Body.Close()
+			if statusCode == http.StatusOK {
+				log.Printf("[DEBUG] API successfully connected.")
+				return nil
+			}
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+
+	return fmt.Errorf("could not contact API: timeout reached")
 }

--- a/ironic/resource_ironic_allocation_v1.go
+++ b/ironic/resource_ironic_allocation_v1.go
@@ -68,7 +68,10 @@ func resourceAllocationV1() *schema.Resource {
 
 // Create an allocation, including driving Ironic's state machine
 func resourceAllocationV1Create(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	result, err := allocations.Create(client, allocationSchemaToCreateOpts(d)).Extract()
 	if err != nil {
@@ -110,7 +113,10 @@ func resourceAllocationV1Create(d *schema.ResourceData, meta interface{}) error 
 
 // Read the allocation's data from Ironic
 func resourceAllocationV1Read(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	result, err := allocations.Get(client, d.Id()).Extract()
 	if err != nil {
@@ -131,9 +137,12 @@ func resourceAllocationV1Read(d *schema.ResourceData, meta interface{}) error {
 
 // Delete an allocation from Ironic if it exists
 func resourceAllocationV1Delete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
-	_, err := allocations.Get(client, d.Id()).Extract()
+	_, err = allocations.Get(client, d.Id()).Extract()
 	if _, ok := err.(gophercloud.ErrDefault404); ok {
 		return nil
 	}

--- a/ironic/resource_ironic_allocation_v1_test.go
+++ b/ironic/resource_ironic_allocation_v1_test.go
@@ -55,7 +55,10 @@ func TestAccIronicAllocation(t *testing.T) {
 // Calls gophercloud directly to ensure the allocation exists
 func testAccCheckAllocationExists(name string, allocation *allocations.Allocation) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		client := testAccProvider.Meta().(Clients).Ironic
+		client, err := testAccProvider.Meta().(*Clients).GetIronicClient()
+		if err != nil {
+			return err
+		}
 
 		rs, ok := state.RootModule().Resources[name]
 		if !ok {
@@ -79,7 +82,10 @@ func testAccCheckAllocationExists(name string, allocation *allocations.Allocatio
 
 // Calls gophercloud to ensure the allocation was destroyed
 func testAccAllocationDestroy(state *terraform.State) error {
-	client := testAccProvider.Meta().(Clients).Ironic
+	client, err := testAccProvider.Meta().(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "ironic_allocation_v1" {

--- a/ironic/resource_ironic_deployment.go
+++ b/ironic/resource_ironic_deployment.go
@@ -59,7 +59,10 @@ func resourceDeployment() *schema.Resource {
 
 // Create an deployment, including driving Ironic's state machine
 func resourceDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	// Reload the resource before returning
 	defer resourceDeploymentRead(d, meta)
@@ -94,7 +97,10 @@ func resourceDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
 
 // Read the deployment's data from Ironic
 func resourceDeploymentRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	// Ensure node exists first
 	id := d.Get("node_uuid").(string)
@@ -111,6 +117,10 @@ func resourceDeploymentRead(d *schema.ResourceData, meta interface{}) error {
 
 // Delete an deployment from Ironic - this cleans the node and returns it's state to 'available'
 func resourceDeploymentDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
+
 	return ChangeProvisionStateToTarget(client, d.Id(), "deleted", nil)
 }

--- a/ironic/resource_ironic_deployment_test.go
+++ b/ironic/resource_ironic_deployment_test.go
@@ -39,7 +39,10 @@ func TestAccIronicDeployment(t *testing.T) {
 }
 
 func testAccDeploymentDestroy(state *terraform.State) error {
-	client := testAccProvider.Meta().(Clients).Ironic
+	client, err := testAccProvider.Meta().(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "ironic_node_v1" {

--- a/ironic/resource_ironic_node_v1.go
+++ b/ironic/resource_ironic_node_v1.go
@@ -180,7 +180,10 @@ func resourceNodeV1() *schema.Resource {
 
 // Create a node, including driving Ironic's state machine
 func resourceNodeV1Create(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	// Create the node object in Ironic
 	createOpts := schemaToCreateOpts(d)
@@ -266,7 +269,10 @@ func resourceNodeV1Create(d *schema.ResourceData, meta interface{}) error {
 
 // Read the node's data from Ironic
 func resourceNodeV1Read(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	node, err := nodes.Get(client, d.Id()).Extract()
 	if err != nil {
@@ -306,7 +312,10 @@ func resourceNodeV1Read(d *schema.ResourceData, meta interface{}) error {
 
 // Update a node's state based on the terraform config - TODO: handle everything
 func resourceNodeV1Update(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	d.Partial(true)
 
@@ -403,7 +412,11 @@ func resourceNodeV1Update(d *schema.ResourceData, meta interface{}) error {
 
 // Delete a node from Ironic
 func resourceNodeV1Delete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
+
 	if err := ChangeProvisionStateToTarget(client, d.Id(), "deleted", nil); err != nil {
 		return err
 	}

--- a/ironic/resource_ironic_node_v1_test.go
+++ b/ironic/resource_ironic_node_v1_test.go
@@ -103,7 +103,10 @@ func TestAccIronicNode(t *testing.T) {
 
 func CheckNodeExists(name string, node *nodes.Node) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		client := testAccProvider.Meta().(Clients).Ironic
+		client, err := testAccProvider.Meta().(*Clients).GetIronicClient()
+		if err != nil {
+			return err
+		}
 
 		rs, ok := state.RootModule().Resources[name]
 		if !ok {
@@ -126,7 +129,10 @@ func CheckNodeExists(name string, node *nodes.Node) resource.TestCheckFunc {
 }
 
 func testAccNodeDestroy(state *terraform.State) error {
-	client := testAccProvider.Meta().(Clients).Ironic
+	client, err := testAccProvider.Meta().(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "ironic_node_v1" {

--- a/ironic/resource_ironic_port_v1.go
+++ b/ironic/resource_ironic_port_v1.go
@@ -50,7 +50,11 @@ func resourcePortV1() *schema.Resource {
 }
 
 func resourcePortV1Create(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
+
 	opts := portSchemaToCreateOpts(d)
 	result, err := ports.Create(client, opts).Extract()
 	if err != nil {
@@ -62,7 +66,11 @@ func resourcePortV1Create(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePortV1Read(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(Clients).Ironic
+	client, err := meta.(*Clients).GetIronicClient()
+	if err != nil {
+		return err
+	}
+
 	port, err := ports.Get(client, d.Id()).Extract()
 	if err != nil {
 		return err


### PR DESCRIPTION
If a timeout is specified, the provider will retry connecting to the API
until the timeout is reached. This can be useful when, for example,
another terraform provider is responsible for creating the Ironic
infrastructure. This is a hack, because terraform doesn't truly
understand depends_on relationships between providers.

This approach has limitations: it only works correctly on the first time
the infrastructure is created. If Ironic goes down you cannot rely on a
subsequent run of the other provider to repair Ironic, as Terraform will
expect to be able to talk to the API during the planning stage. This
isn't relevant to the Metal3 use case, as we only ever run apply once.