### PR TITLE
Wait for drivers to become available

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -169,12 +169,13 @@
   version = "v2.0.4"
 
 [[projects]]
-  digest = "1:62f8400a14a90bd0004474b98f287a6715724db3e09f9cb1780503b9ff4c9bd5"
+  digest = "1:b2f0b8003acc6a0c9ede147195126c183dd972df68069ec9917f2e4ade61605a"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
     "openstack/baremetal/noauth",
     "openstack/baremetal/v1/allocations",
+    "openstack/baremetal/v1/drivers",
     "openstack/baremetal/v1/nodes",
     "openstack/baremetal/v1/ports",
     "openstack/baremetalintrospection/noauth",
@@ -783,10 +784,12 @@
     "github.com/gophercloud/gophercloud",
     "github.com/gophercloud/gophercloud/openstack/baremetal/noauth",
     "github.com/gophercloud/gophercloud/openstack/baremetal/v1/allocations",
+    "github.com/gophercloud/gophercloud/openstack/baremetal/v1/drivers",
     "github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes",
     "github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports",
     "github.com/gophercloud/gophercloud/openstack/baremetalintrospection/noauth",
     "github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection",
+    "github.com/gophercloud/gophercloud/pagination",
     "github.com/gophercloud/gophercloud/testhelper",
     "github.com/gophercloud/utils/openstack/baremetal/v1/nodes",
     "github.com/hashicorp/terraform/config",

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/drivers/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/drivers/doc.go
@@ -1,0 +1,43 @@
+/*
+Package drivers contains the functionality for Listing drivers, driver details,
+driver properties and driver logical disk properties
+
+API reference: https://developer.openstack.org/api-ref/baremetal/#drivers-drivers
+
+Example to List Drivers
+
+	drivers.ListDrivers(client.ServiceClient(), drivers.ListDriversOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		driversList, err := drivers.ExtractDrivers(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, n := range driversList {
+			// Do something
+		}
+
+		return true, nil
+	})
+
+Example to Get single Driver Details
+
+	showDriverDetails, err := drivers.GetDriverDetails(client, "ipmi").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Get single Driver Properties
+
+	showDriverProperties, err := drivers.GetDriverProperties(client, "ipmi").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Get single Driver Logical Disk Properties
+
+	showDriverDiskProperties, err := drivers.GetDriverDiskProperties(client, "ipmi").Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package drivers

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/drivers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/drivers/requests.go
@@ -1,0 +1,70 @@
+package drivers
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListDriversOptsBuilder allows extensions to add additional parameters to the
+// ListDrivers request.
+type ListDriversOptsBuilder interface {
+	ToListDriversOptsQuery() (string, error)
+}
+
+// ListDriversOpts defines query options that can be passed to ListDrivers
+type ListDriversOpts struct {
+	// Provide detailed information about the drivers
+	Detail bool `q:"detail"`
+
+	// Filter the list by the type of the driver
+	Type string `q:"type"`
+}
+
+// ToListDriversOptsQuery formats a ListOpts into a query string
+func (opts ListDriversOpts) ToListDriversOptsQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// ListDrivers makes a request against the API to list all drivers
+func ListDrivers(client *gophercloud.ServiceClient, opts ListDriversOptsBuilder) pagination.Pager {
+	url := driversURL(client)
+	if opts != nil {
+		query, err := opts.ToListDriversOptsQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return DriverPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// GetDriverDetails Shows details for a driver
+func GetDriverDetails(client *gophercloud.ServiceClient, driverName string) (r GetDriverResult) {
+	_, r.Err = client.Get(driverDetailsURL(client, driverName), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// GetDriverProperties Shows the required and optional parameters that
+// driverName expects to be supplied in the driver_info field for every
+// Node it manages
+func GetDriverProperties(client *gophercloud.ServiceClient, driverName string) (r GetPropertiesResult) {
+	_, r.Err = client.Get(driverPropertiesURL(client, driverName), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// GetDriverDiskProperties Show the required and optional parameters that
+// driverName expects to be supplied in the node’s raid_config field, if a
+// RAID configuration change is requested.
+func GetDriverDiskProperties(client *gophercloud.ServiceClient, driverName string) (r GetDiskPropertiesResult) {
+	_, r.Err = client.Get(driverDiskPropertiesURL(client, driverName), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/drivers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/drivers/results.go
@@ -1,0 +1,198 @@
+package drivers
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type driverResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any driverResult as a Driver, if possible.
+func (r driverResult) Extract() (*Driver, error) {
+	var s Driver
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r driverResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
+}
+
+func ExtractDriversInto(r pagination.Page, v interface{}) error {
+	return r.(DriverPage).Result.ExtractIntoSlicePtr(v, "drivers")
+}
+
+// Driver represents a driver in the OpenStack Bare Metal API.
+type Driver struct {
+	// Name and Identifier of the driver
+	Name string `json:"name"`
+
+	// A list of active hosts that support this driver
+	Hosts []string `json:"hosts"`
+
+	// Type of this driver (“classic” or “dynamic”)
+	Type string `json:"type"`
+
+	// The default bios interface used for a node with a dynamic driver,
+	// if no bios interface is specified for the node.
+	DefaultBiosInterface string `json:"default_bios_interface"`
+
+	// The default boot interface used for a node with a dynamic driver,
+	// if no boot interface is specified for the node.
+	DefaultBootInterface string `json:"default_boot_interface"`
+
+	// The default console interface used for a node with a dynamic driver,
+	// if no console interface is specified for the node.
+	DefaultConsoleInterface string `json:"default_console_interface"`
+
+	// The default deploy interface used for a node with a dynamic driver,
+	// if no deploy interface is specified for the node.
+	DefaultDeployInterface string `json:"default_deploy_interface"`
+
+	// The default inspection interface used for a node with a dynamic driver,
+	// if no inspection interface is specified for the node.
+	DefaultInspectInterface string `json:"default_inspect_interface"`
+
+	// The default management interface used for a node with a dynamic driver,
+	// if no management interface is specified for the node.
+	DefaultManagementInterface string `json:"default_management_interface"`
+
+	// The default network interface used for a node with a dynamic driver,
+	// if no network interface is specified for the node.
+	DefaultNetworkInterface string `json:"default_network_interface"`
+
+	// The default power interface used for a node with a dynamic driver,
+	// if no power interface is specified for the node.
+	DefaultPowerInterface string `json:"default_power_interface"`
+
+	// The default RAID interface used for a node with a dynamic driver,
+	// if no RAID interface is specified for the node.
+	DefaultRaidInterface string `json:"default_raid_interface"`
+
+	// The default rescue interface used for a node with a dynamic driver,
+	// if no rescue interface is specified for the node.
+	DefaultRescueInterface string `json:"default_rescue_interface"`
+
+	// The default storage interface used for a node with a dynamic driver,
+	// if no storage interface is specified for the node.
+	DefaultStorageInterface string `json:"default_storage_interface"`
+
+	// The default vendor interface used for a node with a dynamic driver,
+	// if no vendor interface is specified for the node.
+	DefaultVendorInterface string `json:"default_vendor_interface"`
+
+	// The enabled bios interfaces for this driver.
+	EnabledBiosInterfaces []string `json:"enabled_bios_interfaces"`
+
+	// The enabled boot interfaces for this driver.
+	EnabledBootInterfaces []string `json:"enabled_boot_interfaces"`
+
+	// The enabled console interfaces for this driver.
+	EnabledConsoleInterface []string `json:"enabled_console_interfaces"`
+
+	// The enabled deploy interfaces for this driver.
+	EnabledDeployInterfaces []string `json:"enabled_deploy_interfaces"`
+
+	// The enabled inspection interfaces for this driver.
+	EnabledInspectInterfaces []string `json:"enabled_inspect_interfaces"`
+
+	// The enabled management interfaces for this driver.
+	EnabledManagementInterfaces []string `json:"enabled_management_interfaces"`
+
+	// The enabled network interfaces for this driver.
+	EnabledNetworkInterfaces []string `json:"enabled_network_interfaces"`
+
+	// The enabled power interfaces for this driver.
+	EnabledPowerInterfaces []string `json:"enabled_power_interfaces"`
+
+	// The enabled rescue interfaces for this driver.
+	EnabledRescueInterfaces []string `json:"enabled_rescue_interfaces"`
+
+	// The enabled RAID interfaces for this driver.
+	EnabledRaidInterfaces []string `json:"enabled_raid_interfaces"`
+
+	// The enabled storage interfaces for this driver.
+	EnabledStorageInterfaces []string `json:"enabled_storage_interfaces"`
+
+	// The enabled vendor interfaces for this driver.
+	EnabledVendorInterfaces []string `json:"enabled_vendor_interfaces"`
+
+	//A list of relative links. Includes the self and bookmark links.
+	Links []interface{} `json:"links"`
+
+	// A list of links to driver properties.
+	Properties []interface{} `json:"properties"`
+}
+
+// DriverPage abstracts the raw results of making a ListDrivers() request
+// against the API.
+type DriverPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a page contains no Driver results.
+func (r DriverPage) IsEmpty() (bool, error) {
+	s, err := ExtractDrivers(r)
+	return len(s) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (r DriverPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"drivers_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractDrivers interprets the results of a single page from ListDrivers()
+// call, producing a slice of Driver entities.
+func ExtractDrivers(r pagination.Page) ([]Driver, error) {
+	var s []Driver
+	err := ExtractDriversInto(r, &s)
+	return s, err
+}
+
+// GetDriverResult is the response from a Get operation.
+// Call its Extract method to interpret it as a Driver.
+type GetDriverResult struct {
+	driverResult
+}
+
+// DriverProperties represents driver properties in the OpenStack Bare Metal API.
+type DriverProperties map[string]interface{}
+
+// Extract interprets any GetPropertiesResult as DriverProperties, if possible.
+func (r GetPropertiesResult) Extract() (*DriverProperties, error) {
+	var s DriverProperties
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// GetPropertiesResult is the response from a GetDriverProperties operation.
+// Call its Extract method to interpret it as DriverProperties.
+type GetPropertiesResult struct {
+	gophercloud.Result
+}
+
+// DiskProperties represents driver disk properties in the OpenStack Bare Metal API.
+type DiskProperties map[string]interface{}
+
+// Extract interprets any GetDiskPropertiesResult as DiskProperties, if possible.
+func (r GetDiskPropertiesResult) Extract() (*DiskProperties, error) {
+	var s DiskProperties
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// GetDiskPropertiesResult is the response from a GetDriverDiskProperties operation.
+// Call its Extract method to interpret it as DiskProperties.
+type GetDiskPropertiesResult struct {
+	gophercloud.Result
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/drivers/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/drivers/urls.go
@@ -1,0 +1,19 @@
+package drivers
+
+import "github.com/gophercloud/gophercloud"
+
+func driversURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("drivers")
+}
+
+func driverDetailsURL(client *gophercloud.ServiceClient, driverName string) string {
+	return client.ServiceURL("drivers", driverName)
+}
+
+func driverPropertiesURL(client *gophercloud.ServiceClient, driverName string) string {
+	return client.ServiceURL("drivers", driverName, "properties")
+}
+
+func driverDiskPropertiesURL(client *gophercloud.ServiceClient, driverName string) string {
+	return client.ServiceURL("drivers", driverName, "raid", "logical_disk_properties")
+}


### PR DESCRIPTION
Currently, the code that polls the Ironic API, only checks if / is
responding.  Once / responds, we should check the drivers endpoint to
see if any drivers are available. This indicates that the conductor is
up and responding as well.  Otherwise, we risk terraform trying to begin
its work with conductor not fully up.