### PR TITLE
Handle 409 conflict errors from Ironic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ script:
   - make test
 after_failure:
   - docker logs mariadb
-  - docker exec ironic cat /var/log/ironic/ironic-api.log
-  - docker exec ironic cat /var/log/ironic/ironic-conductor.log
+  - docker exec ironic cat /shared/log/ironic/ironic-api.log
+  - docker exec ironic cat /shared/log/ironic/ironic-conductor.log

--- a/ironic/resource_ironic_deployment.go
+++ b/ironic/resource_ironic_deployment.go
@@ -70,13 +70,13 @@ func resourceDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
 	// Set instance info
 	instanceInfo := d.Get("instance_info").(map[string]interface{})
 	if instanceInfo != nil {
-		_, err := nodes.Update(client, d.Get("node_uuid").(string), nodes.UpdateOpts{
+		_, err := UpdateNode(client, d.Get("node_uuid").(string), nodes.UpdateOpts{
 			nodes.UpdateOperation{
 				Op:    nodes.AddOp,
 				Path:  "/instance_info",
 				Value: instanceInfo,
 			},
-		}).Extract()
+		})
 		if err != nil {
 			return fmt.Errorf("could not update instance info: %s", err)
 		}


### PR DESCRIPTION
When Ironic returns a 409 result, it could be that the node is locked
while another operation is being performed, like checking power status.
This error shouldn't be fatal, and we should retry a few times to see if
the lock gets released.