### PR TITLE
Update CI go version to 1.13.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 env:
   - TF_LOG=debug TF_ACC=true TAGS="acceptance"
 go:
-  - 1.11.x
+  - 1.13.x
 git:
   depth: 1
   go_import_path: github.com/openshift-metal3/terraform-provider-ironic


### PR DESCRIPTION
Need to update CI's go version to accommodate net/url's new methods.