### PR TITLE
Add user_data_url_headers

### DIFF
--- a/ironic/resource_ironic_deployment_test.go
+++ b/ironic/resource_ironic_deployment_test.go
@@ -164,7 +164,8 @@ func TestFetchFullIgnition(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		userData, err := fetchFullIgnition(tc.UserDataURL, tc.UserDataURLCACert)
+		emptyHeaders := make(map[string]interface{})
+		userData, err := fetchFullIgnition(tc.UserDataURL, tc.UserDataURLCACert, emptyHeaders)
 		if err != nil {
 			t.Errorf("expected err: %s", err)
 		}

--- a/ironic/resource_ironic_deployment_test.go
+++ b/ironic/resource_ironic_deployment_test.go
@@ -164,7 +164,10 @@ func TestFetchFullIgnition(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		userData := fetchFullIgnition(tc.UserDataURL, tc.UserDataURLCACert)
+		userData, err := fetchFullIgnition(tc.UserDataURL, tc.UserDataURLCACert)
+		if err != nil {
+			t.Errorf("expected err: %s", err)
+		}
 		if tc.ExpectResult && (userData != "Full Ignition\n") {
 			t.Errorf("expected userData: %s, got %s", "Full Ignition\n", userData)
 		}


### PR DESCRIPTION
When retrieving user_data_url from some sources it's necessary to include headers to get the desired result, in particular when
reading data from the MCS on OpenShift it's necessary to include
    
    "Accept: application/vnd.coreos.ignition+json; version=3.1.0"
    
Otherwise the GET returns a 2.2.0 config which isn't compatible with the latest OS images.
    
https://github.com/openshift/machine-config-operator/blob/master/docs/HACKING.md#accessing-the-machineconfigserver-directly

Also adjusted the error handling so it's clearer if there's a problem retrieving the config as previously this was silently ignored.