### PR TITLE
Add script/doc about running local acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ Available data points are:
     - ip
     - mac
 
+# Development
+
+## Running acceptance tests locally
+
+To run the acceptance tests locally, it's necessary to have a local instance of
+ironic and ironic-inspector running.  A similar configuration to that used in
+CI can be achieved by running `hack/local_ironic.sh`
+
 # License
 
 Apache 2.0, See LICENSE file

--- a/hack/local_ironic.sh
+++ b/hack/local_ironic.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -xe
+
+sudo podman run -d --net host --name mariadb --entrypoint /bin/runmariadb quay.io/metal3-io/ironic:master
+sudo podman run -d --net host --name ironic -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
+sudo podman run -d --net host --name ironic-inspector -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic-inspector:master
+
+for p in 3306 6385 5050; do
+  nc -z -w 60 127.0.0.1 ${p}
+done


### PR DESCRIPTION
To make it clearer how to run the acceptance tests locally, add
a script that sets up some containers in a similar way to CI,
and mention it in the README