### PR TITLE
Fix unit tests and local_ironic.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_install:
   - sudo apt-get install -y genisoimage
 before_script:
   - docker run -d --net host --privileged --name mariadb --entrypoint /bin/runmariadb quay.io/metal3-io/ironic:master
-  - docker run -d --net host --privileged -e "PROVISIONING_IP=127.0.0.1" --name ironic quay.io/metal3-io/ironic:master
+  - docker run -d --net host --name ironic-api --entrypoint /bin/runironic-api -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
+  - docker run -d --net host --name ironic-conductor --entrypoint /bin/runironic-conductor -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
   - docker run -d --net host --privileged -e "PROVISIONING_IP=127.0.0.1" --net host quay.io/metal3-io/ironic-inspector:master
   - docker run --net host -e TARGETS=127.0.0.1:3306,127.0.0.1:6385,127.0.0.1:5050 -e TIMEOUT=60 waisbrot/wait
 script:
@@ -24,5 +25,5 @@ script:
   - make test
 after_failure:
   - docker logs mariadb
-  - docker exec ironic cat /shared/log/ironic/ironic-api.log
-  - docker exec ironic cat /shared/log/ironic/ironic-conductor.log
+  - docker exec ironic-api cat /shared/log/ironic/ironic-api.log
+  - docker exec ironic-conductor cat /shared/log/ironic/ironic-conductor.log

--- a/hack/local_ironic.sh
+++ b/hack/local_ironic.sh
@@ -3,7 +3,8 @@
 set -xe
 
 sudo podman run -d --net host --name mariadb --entrypoint /bin/runmariadb quay.io/metal3-io/ironic:master
-sudo podman run -d --net host --name ironic -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
+sudo podman run -d --net host --name ironic-api --entrypoint /bin/runironic-api -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
+sudo podman run -d --net host --name ironic-conductor --entrypoint /bin/runironic-conductor -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
 sudo podman run -d --net host --name ironic-inspector -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic-inspector:master
 
 for p in 3306 6385 5050; do

--- a/ironic/resource_ironic_node_v1_test.go
+++ b/ironic/resource_ironic_node_v1_test.go
@@ -1,3 +1,5 @@
+// +build acceptance
+
 package ironic
 
 import (


### PR DESCRIPTION
1. ironic/resource_ironic_node_v1_test.go depends on symbols in files with "+build acceptance" and so it needs that tag also.
2. the default entrypoint of the ironic image does not exist (/bin/runironic). and it needs both the api and conductor for the unit tests to run.

/cc @hardys 