### PR TITLE
Handle capabilities in instance_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ resource "ironic_deployment" "masters" {
   instance_info = {
     image_source   = "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
     image_checksum = "26c53f3beca4e0b02e09d335257826fd"
+    capabilities   = "boot_option:local,secure_boot:true"
   }
 
   user_data    = var.user_data


### PR DESCRIPTION
This commit adds a parser for capabilities when they
are defined in instance_info.
The capabilities should be provided as a single string,
in the format `key1:value1,key2:value2`, this will be
parsed and sent to ironic as a
map[string]string{"key1":"value1","key2":"value2"}