### PR TITLE
Delete the redundant `--net host` in the docker command line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - docker run -d --net host --privileged --name mariadb --entrypoint /bin/runmariadb quay.io/metal3-io/ironic:master
   - docker run -d --net host --name ironic-api --entrypoint /bin/runironic-api -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
   - docker run -d --net host --name ironic-conductor --entrypoint /bin/runironic-conductor -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
-  - docker run -d --net host --privileged -e "PROVISIONING_IP=127.0.0.1" --net host quay.io/metal3-io/ironic-inspector:master
+  - docker run -d --net host --privileged -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic-inspector:master
   - docker run --net host -e TARGETS=127.0.0.1:3306,127.0.0.1:6385,127.0.0.1:5050 -e TIMEOUT=60 waisbrot/wait
 script:
   - make fmt


### PR DESCRIPTION
The following is the error of CI:
```
$ docker run -d --net host --privileged -e "PROVISIONING_IP=127.0.0.1" --net host quay.io/metal3-io/ironic-inspector:master
docker: network "host" is specified multiple times.
```

It is caused by specifying `--net host` twice.

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>