### PR TITLE
Add fmt-check into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ install: default
 	mkdir -p ${TERRAFORM_PLUGINS}
 	mv terraform-provider-ironic ${TERRAFORM_PLUGINS}
 
+fmt-check:
+	go fmt -s -d -e ./ironic
+
 fmt:
 	go fmt ./ironic .
 


### PR DESCRIPTION
This PR adds `fmt-check` into Makefile. Thanks to that, there will be fmt check step in prow jobs of this repository.