### PR TITLE
Fix CI: Run mariadb container from mariadb-image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 before_install:
   - sudo apt-get install -y genisoimage
 before_script:
-  - docker run -d --net host --privileged --name mariadb --entrypoint /bin/runmariadb quay.io/metal3-io/ironic:master
+  - docker run -d --net host --privileged --name mariadb quay.io/metal3-io/mariadb:main
   - docker run -d --net host --name ironic-api --entrypoint /bin/runironic-api -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
   - docker run -d --net host --name ironic-conductor --entrypoint /bin/runironic-conductor -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
   - docker run -d --net host --privileged -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic-inspector:master


### PR DESCRIPTION
ironic-image has dropped runmariadb in favor of [mariadb-image](https://github.com/metal3-io/mariadb-image) since https://github.com/metal3-io/ironic-image/pull/339

fix: https://github.com/openshift-metal3/terraform-provider-ironic/issues/63

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>