### PR TITLE
CI: use combined Ironic, drop MariaDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,9 @@ services:
 before_install:
   - sudo apt-get install -y genisoimage
 before_script:
-  - docker run -d --net host --privileged --name mariadb quay.io/metal3-io/mariadb:main
-  - docker run -d --net host --name ironic-api --entrypoint /bin/runironic-api -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
-  - docker run -d --net host --name ironic-conductor --entrypoint /bin/runironic-conductor -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:master
+  - docker run -d --net host --privileged --name ironic --entrypoint /bin/runironic -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic:main
   - docker run -d --net host --privileged -e "PROVISIONING_IP=127.0.0.1" quay.io/metal3-io/ironic-inspector:master
-  - docker run --net host -e TARGETS=127.0.0.1:3306,127.0.0.1:6385,127.0.0.1:5050 -e TIMEOUT=60 waisbrot/wait
+  - docker run --net host -e TARGETS=127.0.0.1:6385,127.0.0.1:5050 -e TIMEOUT=60 waisbrot/wait
 script:
   - make fmt
   - make lint


### PR DESCRIPTION
Replace 3 containers(mariadb, ironic-api, ironic-conductor) with the combined one(ironic) to improve CI.

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>